### PR TITLE
If global flag is set, return it in the aggregation array.

### DIFF
--- a/src/DESConnector/Elasticsearch/Aggregations/Aggregation.php
+++ b/src/DESConnector/Elasticsearch/Aggregations/Aggregation.php
@@ -108,7 +108,8 @@ abstract class Aggregation implements AggregationInterface
                 // TODO: Check if global is available for all Aggregations or it is bind
                 // to Bucket only.
                 // TODO: Global to make it as const.
-                'global' => array(),
+                // Global has to be an (empty) object.
+                'global' => new \stdClass(),
                 Aggregations::AGGS_STRING => $aggregation,
             );
         }

--- a/src/DESConnector/Elasticsearch/Aggregations/Aggregations.php
+++ b/src/DESConnector/Elasticsearch/Aggregations/Aggregations.php
@@ -108,6 +108,9 @@ class Aggregations implements AggregationsInterface
         foreach ($this->aggregations as $name => $aggregationObj) {
             $aggsArray = $aggregationObj->constructAggregation();
             $aggregationArray[$name] = $aggsArray[$name];
+            if (isset($aggsArray[$name . '_global'])) {
+              $aggregationArray[$name . '_global'] = $aggsArray[$name . '_global'];
+            }
         }
 
         if (!empty($aggregationArray)) {


### PR DESCRIPTION
We have a requirement to allow 'or' search facets. This was not possible because:

- No global buckets were returned
- The global parameter has to be an (empty) object

This patch remedies this. Note that the patch will add the global results in the array, so the Drupal elasticsearch connector module will throw undefined index notices if it is not patched (patch will be posted there shortly in this issue: https://www.drupal.org/node/2918929)