### PR TITLE
Make sure the size parameter is also set when the global option is set.

### DIFF
--- a/src/DESConnector/Elasticsearch/Aggregations/Bucket/Terms.php
+++ b/src/DESConnector/Elasticsearch/Aggregations/Bucket/Terms.php
@@ -41,6 +41,10 @@ class Terms extends Bucket
         // Set the additional parameters if needed.
         if (isset($this->size)) {
             $aggregation[$this->name][static::TYPE]['size'] = $this->size;
+            // Also set the parameters if global name is set.
+            if (isset($aggregation[$this->name . '_global'])) {
+              $aggregation[$this->name . '_global']['aggs'][$this->name][static::TYPE]['size'] = $this->size;
+            }
         }
 
         if (isset($this->order)) {


### PR DESCRIPTION
I found that the previous patch did not take into account the size parameter when the global option is set. This patch fixes that.