### PR TITLE
Support using 'min_doc_count' parameter in terms aggregation.

### DIFF
--- a/src/DESConnector/Elasticsearch/Aggregations/Bucket/Terms.php
+++ b/src/DESConnector/Elasticsearch/Aggregations/Bucket/Terms.php
@@ -34,6 +34,14 @@ class Terms extends Bucket
         $this->order = $order;
     }
 
+    /**
+     * @param $value
+     */
+    public function setMinDocCount($value)
+    {
+        $this->addParameter('min_doc_count', $value);
+    }
+
     public function constructAggregation()
     {
         $aggregation = parent::constructAggregation();


### PR DESCRIPTION
This is a prerequisite to fix the following Drupal module issue: https://www.drupal.org/project/elasticsearch_connector/issues/2923076