### PR TITLE
Fix aggregations check in the search function.

### DIFF
--- a/src/DESConnector/Client.php
+++ b/src/DESConnector/Client.php
@@ -351,7 +351,7 @@ class Client implements ClientInterface
      */
     public function search($params)
     {
-        if (empty($params[Aggregations::AGGS_STRING]) && $this->aggregations()
+        if (empty($params['body'][Aggregations::AGGS_STRING]) && $this->aggregations()
                 ->hasAggregations()
         ) {
             $this->aggregations()->applyAggregationsToParams($params);


### PR DESCRIPTION
Aggregations are actually stored in `$params['body']['aggs']`, not in `$params['aggs']`.

Without this bugfix, `aggs` always gets rebuilt right before search. Hence making all aggregations altering void (e.g. altering `$params['body']['aggs']` in `hook_elasticsearch_connector_search_api_query_alter()`).