### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.1
   - 7.2
   - 8.0
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 8.0
 before_install:
   - travis_retry composer self-update
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "homepage": "https://github.com/nodespark/des-connector",
   "require": {
-    "php": "^7.0",
+    "php": "^7.0 || ^8.0",
     "ruflin/Elastica": "dev-master"
   },
   "license": "LGPL-2.1",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "homepage": "https://github.com/nodespark/des-connector",
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.2 || ^8.0",
     "ruflin/elastica": "dev-master"
   },
   "license": "LGPL-2.1",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "type": "library",
   "homepage": "https://github.com/nodespark/des-connector",
   "require": {
-    "php": "^7.0 || ^8.0",
-    "ruflin/Elastica": "dev-master"
+    "php": "^7.1 || ^8.0",
+    "ruflin/elastica": "dev-master"
   },
   "license": "LGPL-2.1",
   "authors": [
@@ -36,6 +36,6 @@
     "source": "https://github.com/nodespark/des-connector"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.3"
+    "phpunit/phpunit": "^8.4.1 || ^9"
   }
 }

--- a/src/DESConnector/Elasticsearch/Aggregations/Aggregations.php
+++ b/src/DESConnector/Elasticsearch/Aggregations/Aggregations.php
@@ -65,7 +65,7 @@ class Aggregations implements AggregationsInterface
      *
      * @return void
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 
@@ -73,7 +73,7 @@ class Aggregations implements AggregationsInterface
      * Private serialize method to prevent serializing of the *Singleton*
      * instance.
      */
-    private function __sleep()
+    public function __sleep()
     {
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $params = ['hosts' => ['foo', 'bar']];

--- a/tests/Elasticsearch/Aggregations/AggregationTest.php
+++ b/tests/Elasticsearch/Aggregations/AggregationTest.php
@@ -22,7 +22,7 @@ class AggregationTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->aggregation = $this->getMockForAbstractClass('\nodespark\DESConnector\Elasticsearch\Aggregations\Aggregation',
@@ -81,9 +81,7 @@ class AggregationTest extends TestCase {
         ],
       'foo_global' =>
         [
-          'global' =>
-            [
-            ],
+          'global' => new \stdClass(),
           'aggs' =>
             [
               'foo' =>

--- a/tests/Elasticsearch/Aggregations/AggregationsTest.php
+++ b/tests/Elasticsearch/Aggregations/AggregationsTest.php
@@ -23,7 +23,7 @@ class AggregationsTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->aggregations = Aggregations::getInstance('foo');

--- a/tests/Elasticsearch/Aggregations/Bucket/ChildrenTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/ChildrenTest.php
@@ -24,7 +24,7 @@ class ChildrenTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->children = new Children('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Bucket/DateHistogramTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/DateHistogramTest.php
@@ -22,7 +22,7 @@ class DateHistogramTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->dateHistogram = new DateHistogram('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Bucket/DateRangeTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/DateRangeTest.php
@@ -22,7 +22,7 @@ class DateRangeTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->dateRange = new DateRange('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Bucket/HistogramTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/HistogramTest.php
@@ -22,7 +22,7 @@ class HistogramTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->histogram = new Histogram('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Bucket/RangeTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/RangeTest.php
@@ -22,7 +22,7 @@ class RangeTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->range = new Range('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Bucket/TermsTest.php
+++ b/tests/Elasticsearch/Aggregations/Bucket/TermsTest.php
@@ -22,7 +22,7 @@ class TermsTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->terms = new Terms('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Metrics/AvgTest.php
+++ b/tests/Elasticsearch/Aggregations/Metrics/AvgTest.php
@@ -22,7 +22,7 @@ class AvgTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->avg = new Avg('foo', 'bar');

--- a/tests/Elasticsearch/Aggregations/Metrics/CardinalityTest.php
+++ b/tests/Elasticsearch/Aggregations/Metrics/CardinalityTest.php
@@ -22,7 +22,7 @@ class CardinalityTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->cardinality = new Cardinality('foo', 'bar');

--- a/tests/Elasticsearch/Response/SearchResponseTest.php
+++ b/tests/Elasticsearch/Response/SearchResponseTest.php
@@ -45,7 +45,7 @@ class SearchResponseTest extends TestCase {
   /**
    * @inheritDoc
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $this->response = [
@@ -58,7 +58,7 @@ class SearchResponseTest extends TestCase {
       ],
       'hits' => [
         'max_score' => 2,
-        'total' => 100,
+        'total' => ['value' => 100],
         'hits' => [
           'alpha' => 'bravo',
         ],


### PR DESCRIPTION
- Dropped php 7.0 and 7.1 support since ruflin/elastica requires php 7.2+
- Updated phpunit to latest version

I'm not sure what to do with `Aggregations::__wakeup()` and `__sleep()` since you're not allowed to have non-public magic methods:
`The magic method nodespark\DESConnector\Elasticsearch\Aggregations\Aggregations::__wakeup() must have public visibility`.

Maybe make them public and throw an exception if someone attempts to (un)/serialize the object?