### PR TITLE
Use stable version of ruflin/elastica

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/nodespark/des-connector",
   "require": {
     "php": "^7.2 || ^8.0",
-    "ruflin/elastica": "dev-master"
+    "ruflin/elastica": "^7.0"
   },
   "license": "LGPL-2.1",
   "authors": [


### PR DESCRIPTION
Looks like ruflin/elastica has removed the `master` branch:

![image](https://user-images.githubusercontent.com/771113/205621071-13580996-d14e-494e-956d-f01f579fd3df.png)

